### PR TITLE
Make Applicative and Alternative instances much faster

### DIFF
--- a/Control/Monad/Omega.hs
+++ b/Control/Monad/Omega.hs
@@ -44,6 +44,7 @@ where
 import qualified Control.Monad as Monad
 import qualified Control.Applicative as Applicative
 import qualified Data.Foldable as Foldable
+import Data.List (tails)
 import qualified Data.Traversable as Traversable
 
 import qualified Control.Monad.Fail as Fail
@@ -89,7 +90,10 @@ instance Monad.MonadPlus Omega where
 
 instance Applicative.Applicative Omega where
     pure = Omega . (:[])
-    (<*>) = Monad.ap
+    liftA2 f (Omega xs) = Omega . go [] . runOmega
+        where
+            go initYs [] = concatMap (flip (zipWith f) initYs) (tails xs)
+            go initYs (y : ys) = zipWith f xs initYs  ++ go (y : initYs) ys
 
 instance Applicative.Alternative Omega where
     empty = Omega []

--- a/Control/Monad/Omega.hs
+++ b/Control/Monad/Omega.hs
@@ -73,7 +73,7 @@ instance Functor Omega where
     fmap f (Omega xs) = Omega (map f xs)
 
 instance Monad Omega where
-    return x = Omega [x]
+    return = pure
     Omega m >>= f = Omega $ diagonal $ map (runOmega . f) m
 
 #if !(MIN_VERSION_base(4,13,0))
@@ -88,7 +88,7 @@ instance Monad.MonadPlus Omega where
     mplus = (Applicative.<|>)
 
 instance Applicative.Applicative Omega where
-    pure = return
+    pure = Omega . (:[])
     (<*>) = Monad.ap
 
 instance Applicative.Alternative Omega where

--- a/Control/Monad/Omega.hs
+++ b/Control/Monad/Omega.hs
@@ -84,8 +84,8 @@ instance Fail.MonadFail Omega where
     fail _ = Omega []
 
 instance Monad.MonadPlus Omega where
-    mzero = Omega []
-    mplus (Omega xs) (Omega ys) = Omega (diagonal [xs,ys])
+    mzero = Applicative.empty
+    mplus = (Applicative.<|>)
 
 instance Applicative.Applicative Omega where
     pure = return
@@ -93,7 +93,11 @@ instance Applicative.Applicative Omega where
 
 instance Applicative.Alternative Omega where
     empty = Omega []
-    Omega xs <|> Omega ys = Omega (diagonal [xs,ys])
+    Omega xs <|> Omega ys = Omega $ interleave xs ys
+
+interleave :: [a] -> [a] -> [a]
+interleave [] ys = ys
+interleave (x : xs) ys = x : interleave ys xs
 
 instance Foldable.Foldable Omega where
     foldMap f (Omega xs) = Foldable.foldMap f xs

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,0 +1,13 @@
+module Main where
+
+import Control.Applicative
+import Control.Monad.Omega
+import Prelude hiding (Applicative)
+import Test.Tasty.Bench
+
+main :: IO ()
+main = defaultMain
+  [ bench "liftA2" $ nf
+    (\n -> sum $ runOmega $ liftA2 (+) (each [0..n]) (each [0..n]))
+    (100 :: Int)
+  ]

--- a/control-monad-omega.cabal
+++ b/control-monad-omega.cabal
@@ -34,3 +34,14 @@ library
   if !impl(ghc >= 8.0)
     build-depends:
       fail >= 4.9.0.0 && <5
+
+benchmark omega-bench
+  type: exitcode-stdio-1.0
+  default-language: Haskell2010
+  build-depends:
+    base,
+    control-monad-omega,
+    tasty-bench
+  hs-source-dirs: bench
+  main-is: Bench.hs
+  ghc-options: -Wall

--- a/control-monad-omega.cabal
+++ b/control-monad-omega.cabal
@@ -35,6 +35,17 @@ library
     build-depends:
       fail >= 4.9.0.0 && <5
 
+test-suite omega-tests
+  type: exitcode-stdio-1.0
+  default-language: Haskell2010
+  build-depends:
+    base,
+    control-monad-omega,
+    tasty,
+    tasty-quickcheck
+  hs-source-dirs: test
+  main-is: Properties.hs
+
 benchmark omega-bench
   type: exitcode-stdio-1.0
   default-language: Haskell2010
@@ -44,4 +55,3 @@ benchmark omega-bench
     tasty-bench
   hs-source-dirs: bench
   main-is: Bench.hs
-  ghc-options: -Wall

--- a/test/Properties.hs
+++ b/test/Properties.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main where
+
+import Control.Applicative (Applicative(..), (<|>))
+import Control.Monad (join)
+import Control.Monad.Omega
+import Data.List (sort)
+import Prelude hiding (Applicative(..))
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+main :: IO ()
+main = defaultMain $ testGroup "All"
+  [ testProperty "pure" $ \(x :: Int) ->
+    sort (runOmega (pure x)) ===
+      sort (pure x)
+  , testProperty "liftA2" $ \(xs :: [Int]) ys ->
+    sort (runOmega (liftA2 (+) (each xs) (each ys))) ===
+      sort (liftA2 (+) xs ys)
+  , testProperty "(<|>)" $ \(xs :: [Int]) ys ->
+    sort (runOmega (each xs <|> each ys)) ===
+      sort (xs <|> ys)
+  , testProperty "join" $ \(xss :: [[Int]]) ->
+    sort (runOmega (join (each (map each xss)))) ===
+      sort (join xss)
+
+  , testProperty "liftA2 vs. join" $ \(xs :: [Int]) ys ->
+    let f x y = x * 10 + y in
+    runOmega (liftA2 f (each xs) (each ys)) ===
+      runOmega (join (each (map (\x -> each (map (\y -> f x y) ys)) xs)))
+  ]
+


### PR DESCRIPTION
Expressing `instance Applicative (Omega a)` and `instance Alternative (Omega a)` via `instance Monad (Omega a)` is neat, but unfortunately comes with a significant performance penalty. The PR provides optimized definitions for `liftA2` and `(<|>)`. I also added tests and benchmarks to prove that the change is worth doing and does not regress.

Benchmarks before:
```
All
  liftA2: OK
    321  μs ±  29 μs
```

and after:
```
All
  liftA2: OK
    97.1 μs ± 8.5 μs
```